### PR TITLE
Add instructions for date/time field on createRes form

### DIFF
--- a/app/views/createRes.ejs
+++ b/app/views/createRes.ejs
@@ -16,11 +16,11 @@
     </div>
     <div>
       <label>Start Date/Time:</label>
-      <input type="datetime-local" name="startTime" />
+      <input type="datetime-local" name="starttime" /> (Format MM/DD/YYYY HH:MM AM)
     </div>
     <div>
       <label>End Date/Time:</label>
-      <input type="datetime-local" name="endTime" />
+      <input type="datetime-local" name="endTime" /> (Format MM/DD/YYYY HH:MM AM)
     </div>
     <div>
       <label>Area(s) Needed:</label><br />


### PR DESCRIPTION
Resolves #45. Added format instructions for date/time field on createRes form for Firefox and IE users.